### PR TITLE
Remove unused property destructured from useTable example

### DIFF
--- a/examples/material-UI-components/src/App.js
+++ b/examples/material-UI-components/src/App.js
@@ -15,7 +15,6 @@ function Table({ columns, data }) {
   // Use the state and functions returned from useTable to build your UI
   const {
     getTableProps,
-    getTableHeaderProps,
     headerGroups,
     rows,
     prepareRow,


### PR DESCRIPTION
In the Material UI example, I found `getTableHeaderProps` was declared as a property returned by the root `useTable` hook. This was confusing since this function is not documented in the instance properties API or part of the table instance.